### PR TITLE
Feat: Implement full Pet CRUD and enhance Business Recognition UX

### DIFF
--- a/pawsroam-webapp/api/v1/pets/update.php
+++ b/pawsroam-webapp/api/v1/pets/update.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * API Endpoint for Updating an Existing Pet Profile
+ * Method: POST
+ * Expected FormData: pet_id, name, species, [breed], [size], [weight_kg], [birthdate],
+ *                    [personality_traits], [medical_conditions], [dietary_restrictions],
+ *                    [avatar_new (file)], [remove_current_avatar (checkbox value '1')], csrf_token
+ */
+
+// Bootstrap
+if (session_status() == PHP_SESSION_NONE) {
+    session_start(['cookie_httponly' => true, 'cookie_secure' => isset($_SERVER['HTTPS']), 'cookie_samesite' => 'Lax']);
+}
+
+if (!defined('BASE_PATH')) { define('BASE_PATH', dirname(__DIR__, 4)); }
+if (!defined('DS')) { define('DS', DIRECTORY_SEPARATOR); }
+
+$required_files = [
+    BASE_PATH . DS . 'config' . DS . 'constants.php',
+    BASE_PATH . DS . 'config' . DS . 'database.php',
+    BASE_PATH . DS . 'includes' . DS . 'functions.php',
+    BASE_PATH . DS . 'includes' . DS . 'translation.php',
+    BASE_PATH . DS . 'includes' . DS . 'auth.php'
+];
+foreach ($required_files as $file) {
+    if (file_exists($file)) { require_once $file; }
+    else {
+        http_response_code(500); header('Content-Type: application/json');
+        error_log("CRITICAL: Update Pet API failed to load core file: " . $file);
+        echo json_encode(['success' => false, 'message' => 'Server configuration error.']); exit;
+    }
+}
+
+$current_api_language = $GLOBALS['current_language'] ?? DEFAULT_LANGUAGE ?? 'en';
+header('Content-Type: application/json');
+
+// --- Access Control & Request Method Validation ---
+require_login();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => __('error_method_not_allowed', [], $current_api_language)]);
+    exit;
+}
+
+// --- CSRF Token Validation ---
+if (!validate_csrf_token($_POST[CSRF_TOKEN_NAME ?? 'csrf_token'] ?? null)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => __('error_csrf_token_invalid', [], $current_api_language)]);
+    exit;
+}
+
+// --- Input Collection & Pet Ownership Verification ---
+$user_id = current_user_id();
+$pet_id = filter_var($_POST['pet_id'] ?? null, FILTER_VALIDATE_INT);
+$errors = [];
+$current_pet_data = null;
+
+if (!$pet_id || $pet_id <= 0) {
+    $errors['pet_id'] = __('error_invalid_pet_id_for_edit_api', [], $current_api_language); // "Invalid pet ID for update."
+} else {
+    try {
+        $db = Database::getInstance()->getConnection();
+        $stmt = $db->prepare("SELECT * FROM user_pets WHERE id = :pet_id AND user_id = :user_id LIMIT 1");
+        $stmt->bindParam(':pet_id', $pet_id, PDO::PARAM_INT);
+        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt->execute();
+        $current_pet_data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$current_pet_data) {
+            $errors['pet_id'] = __('error_pet_not_found_or_not_owned_api', [], $current_api_language); // "Pet not found or you're not authorized to edit it."
+        }
+    } catch (PDOException $e) {
+        error_log("Update Pet API: DB error fetching pet for ownership check (PetID: {$pet_id}, UserID: {$user_id}): " . $e->getMessage());
+        http_response_code(500);
+        echo json_encode(['success' => false, 'message' => __('error_server_generic', [], $current_api_language)]);
+        exit;
+    }
+}
+
+$name = trim($_POST['name'] ?? '');
+// ... (collect other fields similarly to create.php)
+$species = trim($_POST['species'] ?? '');
+$breed = trim($_POST['breed'] ?? null);
+$size = trim($_POST['size'] ?? null);
+$weight_kg = trim($_POST['weight_kg'] ?? null);
+$birthdate = trim($_POST['birthdate'] ?? null);
+$personality_traits = trim($_POST['personality_traits'] ?? null);
+$medical_conditions = trim($_POST['medical_conditions'] ?? null);
+$dietary_restrictions = trim($_POST['dietary_restrictions'] ?? null);
+$remove_current_avatar = isset($_POST['remove_current_avatar']) && $_POST['remove_current_avatar'] == '1';
+
+
+// --- Input Validation (similar to create.php, but for updates) ---
+// Name
+if (empty($name)) { $errors['name'] = __('error_pet_name_required', [], $current_api_language); }
+elseif (strlen($name) > 100) { $errors['name'] = __('error_pet_name_too_long', [], $current_api_language); }
+// Species
+$allowed_species = ['dog', 'cat', 'bird', 'rabbit', 'other'];
+if (empty($species)) { $errors['species'] = __('error_pet_species_required', [], $current_api_language); }
+elseif (!in_array($species, $allowed_species)) { $errors['species'] = __('error_pet_species_invalid', [], $current_api_language); }
+// Breed
+if ($breed !== null && strlen($breed) > 100) { $errors['breed'] = __('error_pet_breed_too_long', [], $current_api_language); }
+// Size
+$allowed_sizes = ['small', 'medium', 'large', 'extra_large'];
+if ($size !== null && !empty($size) && !in_array($size, $allowed_sizes)) { $errors['size'] = __('error_pet_size_invalid', [], $current_api_language); }
+elseif (empty($size)) { $size = null; }
+// Weight
+if ($weight_kg !== null && !empty($weight_kg)) {
+    if (!is_numeric($weight_kg) || (float)$weight_kg <= 0 || (float)$weight_kg > 200) { $errors['weight_kg'] = __('error_pet_weight_invalid', [], $current_api_language); }
+    else { $weight_kg = (float)$weight_kg; }
+} elseif (empty($weight_kg)) { $weight_kg = null; }
+// Birthdate
+if ($birthdate !== null && !empty($birthdate)) {
+    $d = DateTime::createFromFormat('Y-m-d', $birthdate);
+    if (!$d || $d->format('Y-m-d') !== $birthdate) { $errors['birthdate'] = __('error_pet_birthdate_invalid_format', [], $current_api_language); }
+    elseif (new DateTime($birthdate) > new DateTime()) { $errors['birthdate'] = __('error_pet_birthdate_future', [], $current_api_language); }
+} elseif (empty($birthdate)) { $birthdate = null; }
+
+// JSON fields (using function from create.php, ensure it's available or redefine)
+if (!function_exists('prepare_json_field')) { // Basic re-definition if not included via a shared functions file yet by create.php
+    function prepare_json_field($input_string) {
+        if ($input_string === null || $input_string === '') return null;
+        json_decode($input_string); if (json_last_error() == JSON_ERROR_NONE) return $input_string;
+        $array = array_map('trim', explode(',', $input_string)); $array = array_filter($array);
+        return !empty($array) ? json_encode($array) : null;
+    }
+}
+$personality_traits_json = prepare_json_field($personality_traits);
+$medical_conditions_json = prepare_json_field($medical_conditions);
+$dietary_restrictions_json = prepare_json_field($dietary_restrictions);
+
+// --- Avatar Update Logic ---
+$new_avatar_db_path = $current_pet_data['avatar_path'] ?? null; // Start with current path
+$old_avatar_to_delete_on_success = null;
+
+if ($remove_current_avatar) {
+    if (!empty($current_pet_data['avatar_path'])) {
+        $old_avatar_to_delete_on_success = $current_pet_data['avatar_path'];
+    }
+    $new_avatar_db_path = null; // Set to null for DB update
+}
+
+// Check for new avatar upload only if not removing current one (or if remove is false and new is provided)
+if (!$remove_current_avatar && isset($_FILES['avatar_new']) && $_FILES['avatar_new']['error'] !== UPLOAD_ERR_NO_FILE) {
+    if ($_FILES['avatar_new']['error'] === UPLOAD_ERR_OK) {
+        $target_pet_avatar_dir = 'pet-photos' . DS . $user_id;
+        $allowed_mimes = defined('PET_AVATAR_ALLOWED_MIME_TYPES') ? unserialize(PET_AVATAR_ALLOWED_MIME_TYPES) : ['image/jpeg', 'image/png', 'image/gif'];
+        $max_size = (defined('DEFAULT_MAX_UPLOAD_SIZE_MB') ? DEFAULT_MAX_UPLOAD_SIZE_MB * 1024 * 1024 : 2 * 1024 * 1024);
+
+        $upload_result = handle_file_upload('avatar_new', $target_pet_avatar_dir, $allowed_mimes, $max_size, 'pet_avatar_' . $user_id . '_');
+
+        if ($upload_result['success']) {
+            if (!empty($current_pet_data['avatar_path'])) { // If there was an old avatar
+                $old_avatar_to_delete_on_success = $current_pet_data['avatar_path'];
+            }
+            $new_avatar_db_path = $upload_result['filepath']; // Path for DB
+        } else {
+            $errors['avatar_new'] = $upload_result['message'];
+        }
+    } else {
+        // New file submitted but had a PHP upload error
+        $upload_error_fetch = handle_file_upload('avatar_new', 'pet-photos'); // Call to get translated error
+        $errors['avatar_new'] = $upload_error_fetch['message'];
+    }
+}
+
+
+// --- Process or Return Errors ---
+if (!empty($errors)) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => __('error_validation_failed', [], $current_api_language), 'errors' => $errors]);
+    exit;
+}
+
+// --- Database Update ---
+// Construct SET clause dynamically based on what actually changed or needs to be set
+$fields_to_update_sql = [];
+$params_to_bind = [':pet_id' => $pet_id, ':user_id' => $user_id]; // user_id in WHERE for safety
+
+// Compare with $current_pet_data to see what changed
+if ($name !== $current_pet_data['name']) { $fields_to_update_sql[] = "name = :name"; $params_to_bind[':name'] = $name; }
+if ($species !== $current_pet_data['species']) { $fields_to_update_sql[] = "species = :species"; $params_to_bind[':species'] = $species; }
+if ($breed !== $current_pet_data['breed']) { $fields_to_update_sql[] = "breed = :breed"; $params_to_bind[':breed'] = $breed; } // Handles NULL
+if ($size !== $current_pet_data['size']) { $fields_to_update_sql[] = "size = :size"; $params_to_bind[':size'] = $size; }
+if ($weight_kg !== ($current_pet_data['weight_kg'] === null ? null : (float)$current_pet_data['weight_kg'])) { $fields_to_update_sql[] = "weight_kg = :weight_kg"; $params_to_bind[':weight_kg'] = $weight_kg; }
+if ($birthdate !== $current_pet_data['birthdate']) { $fields_to_update_sql[] = "birthdate = :birthdate"; $params_to_bind[':birthdate'] = $birthdate; }
+
+// For JSON fields, compare the JSON string representation or the source text
+if ($personality_traits_json !== $current_pet_data['personality_traits']) { $fields_to_update_sql[] = "personality_traits = :personality_traits"; $params_to_bind[':personality_traits'] = $personality_traits_json; }
+if ($medical_conditions_json !== $current_pet_data['medical_conditions']) { $fields_to_update_sql[] = "medical_conditions = :medical_conditions"; $params_to_bind[':medical_conditions'] = $medical_conditions_json; }
+if ($dietary_restrictions_json !== $current_pet_data['dietary_restrictions']) { $fields_to_update_sql[] = "dietary_restrictions = :dietary_restrictions"; $params_to_bind[':dietary_restrictions'] = $dietary_restrictions_json; }
+
+// Avatar path change
+if ($new_avatar_db_path !== $current_pet_data['avatar_path']) {
+    $fields_to_update_sql[] = "avatar_path = :avatar_path";
+    $params_to_bind[':avatar_path'] = $new_avatar_db_path;
+}
+
+
+if (empty($fields_to_update_sql)) {
+    http_response_code(200);
+    echo json_encode(['success' => true, 'message' => __('edit_pet_no_changes_detected', [], $current_api_language)]); // "No changes detected."
+    exit;
+}
+
+try {
+    $sql = "UPDATE user_pets SET " . implode(', ', $fields_to_update_sql) . " WHERE id = :pet_id AND user_id = :user_id";
+    $stmt_update = $db->prepare($sql);
+
+    // Bind all parameters that were added
+    foreach($params_to_bind as $key => &$val) { // Pass $val by reference
+        $stmt_update->bindParam($key, $val); // Type will be inferred by PDO or can be set explicitly if needed
+    }
+    unset($val); // Break the reference
+
+    if ($stmt_update->execute()) {
+        // If update was successful and an old avatar needs to be deleted
+        if ($old_avatar_to_delete_on_success && defined('UPLOADS_BASE_PATH')) {
+            $full_old_avatar_path = rtrim(UPLOADS_BASE_PATH, DS) . DS . ltrim($old_avatar_to_delete_on_success, DS);
+            if (file_exists($full_old_avatar_path) && is_file($full_old_avatar_path)) {
+                if (!unlink($full_old_avatar_path)) {
+                    error_log("Update Pet API: Failed to delete old avatar file: {$full_old_avatar_path}");
+                    // Non-fatal, profile was updated. Could add a note to success message.
+                } else {
+                     error_log("Update Pet API: Successfully deleted old avatar file: {$full_old_avatar_path}");
+                }
+            }
+        }
+
+        http_response_code(200); // OK
+        echo json_encode([
+            'success' => true,
+            'message' => __('edit_pet_api_success', [], $current_api_language), // "Pet profile updated successfully!"
+            'pet_id' => $pet_id,
+            'new_avatar_path' => $new_avatar_db_path // Send back new path for UI update
+        ]);
+    } else {
+        error_log("Update Pet API: DB execution error for PetID {$pet_id}, UserID {$user_id}.");
+        http_response_code(500);
+        echo json_encode(['success' => false, 'message' => __('edit_pet_api_failed_db', [], $current_api_language)]); // "Failed to update pet profile due to a database error."
+    }
+
+} catch (PDOException $e) {
+    error_log("Update Pet API (PDOException): " . $e->getMessage() . " for PetID {$pet_id}, UserID {$user_id}.");
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => __('error_server_generic', [], $current_api_language)]);
+} catch (Exception $e) {
+    error_log("Update Pet API (Exception): " . $e->getMessage() . " for PetID {$pet_id}, UserID {$user_id}.");
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => __('error_server_generic', [], $current_api_language)]);
+}
+
+exit;
+
+<?php
+// Translation string placeholders
+// __('error_invalid_pet_id_for_edit_api', [], $current_api_language);
+// __('error_pet_not_found_or_not_owned_api', [], $current_api_language);
+// __('edit_pet_no_changes_detected', [], $current_api_language);
+// __('edit_pet_api_success', [], $current_api_language);
+// __('edit_pet_api_failed_db', [], $current_api_language);
+// Plus all validation errors from create.php, if specific keys are needed.
+?>

--- a/pawsroam-webapp/index.php
+++ b/pawsroam-webapp/index.php
@@ -155,13 +155,33 @@ if (array_key_exists($requestedPath, $routes)) {
             error_log("Routing error: add-pet.php not found for route '/pets/add'.");
         }
     }
-    // Example for /pets/edit/{id}, /pets/view/{id} (for future)
+    // Route for editing or viewing a pet: /pets/edit/{id} or /pets/view/{id}
+    elseif (preg_match('#^/pets/(edit|view)/([0-9]+)$#', $requestedPath, $matches)) {
+        $action = $matches[1]; // 'edit' or 'view'
+        $pet_id = (int)$matches[2];
+        $_GET['id'] = $pet_id; // Pass pet_id as 'id' to the page script
+
+        if ($action === 'edit') {
+            $filePath = BASE_PATH . DS . 'pages' . DS . 'pets' . DS . 'edit-pet.php';
+        } elseif ($action === 'view') {
+            $filePath = BASE_PATH . DS . 'pages' . DS . 'pets' . DS . 'view-pet.php';
+        }
+        // else: action unknown, will fall through to 404 if $filePath not set
+
+        if (isset($filePath) && file_exists($filePath)) {
+            $pageToLoad = $filePath;
+            $pageFound = true;
+        } else {
+            error_log("Routing error: Pet page for action '{$action}' with ID '{$pet_id}' not found. File: " . ($filePath ?? 'N/A'));
+        }
+    }
+    // Example for /pets/add, /pets/edit/{id}, /pets/view/{id} (for future)
     // elseif (preg_match('#^/pets/add$#', $requestedPath)) {
     //     // $filePath = BASE_PATH . DS . 'pages' . DS . 'pets' . DS . 'add-edit-pet.php'; // Assuming a combined add/edit form
     //     // $_GET['action'] = 'add';
     //     // if (file_exists($filePath)) { $pageToLoad = $filePath; $pageFound = true; }
     // }
-    elseif (preg_match('#^/pets/(edit|view)/([0-9]+)$#', $requestedPath, $matches)) {
+    // elseif (preg_match('#^/pets/(edit|view)/([0-9]+)$#', $requestedPath, $matches)) {
         // $action = $matches[1]; // 'edit' or 'view'
         // $pet_id = (int)$matches[2];
         // $_GET['action'] = $action;

--- a/pawsroam-webapp/lang/en/common.php
+++ b/pawsroam-webapp/lang/en/common.php
@@ -212,7 +212,7 @@ return [
 
     // Pet Profile Management Page (pages/pet-profile.php)
     'page_title_pet_profiles' => 'My Pet Profiles',
-    'tooltip_add_new_pet' => 'Add a new pet to your profile (Feature coming soon)', // Kept for reference, but new one used
+    'tooltip_add_new_pet' => 'Add a new pet to your profile (Feature coming soon)', // Kept for reference if needed
     'tooltip_add_new_pet_now' => 'Add a new pet to your profile',
     'button_add_new_pet' => 'Add New Pet',
     'error_pet_profiles_load_failed_db' => 'Could not load your pet profiles due to a database error. Please try again.',
@@ -221,15 +221,15 @@ return [
     'pet_profiles_none_found_message' => "You haven't added any pet profiles yet.",
     'button_add_your_first_pet_link_text' => 'add your first pet profile',
     'pet_profiles_add_one_prompt_html %s' => 'It looks a bit empty here! Why not %s and share details about your furry, feathery, or scaly friend?', // %s is for the link
-    'tooltip_add_first_pet' => 'Add your first pet (Feature coming soon)',
+    'tooltip_add_first_pet' => 'Add your first pet now!', // Updated from "coming soon"
     'button_add_your_first_pet' => 'Add Your First Pet', // Button text if not using the link version
-    'pet_profiles_stub_note' => '(Pet listing and management functionality is currently a stub and will be implemented soon!)',
+    'pet_profiles_stub_note' => '(Pet listing and management functionality is currently a stub and will be implemented soon!)', // This can be removed or updated later
     'pet_avatar_alt %s' => '%s\'s avatar', // %s for pet name
-    'tooltip_view_pet %s' => 'View %s\'s full profile (Coming soon)',
+    'tooltip_view_pet_profile %s' => "View %s's full profile", // Updated from generic "coming soon"
     'button_view' => 'View',
-    'tooltip_edit_pet %s' => 'Edit %s\'s profile (Coming soon)',
+    'tooltip_edit_pet_profile %s' => "Edit %s's profile", // Updated from generic "coming soon"
     // 'button_edit' => 'Edit', // Already have a general 'button_edit'
-    'tooltip_delete_pet %s' => 'Delete %s\'s profile (Coming soon)',
+    'tooltip_delete_pet_profile %s' => "Delete %s's profile", // Updated from generic "coming soon"
     // 'button_delete' => 'Delete', // Already have a general 'button_delete'
     'modal_title_delete_pet_confirm %s' => 'Confirm Deletion of %s', // %s for pet name
     'modal_title_delete_pet_confirm_generic' => 'Confirm Pet Deletion',
@@ -328,6 +328,22 @@ return [
     'add_pet_api_success' => 'New pet profile created successfully!',
     'add_pet_api_failed_db' => 'Failed to create pet profile due to a database error. Please try again later.',
 
+    // Edit Pet Page (pages/pets/edit-pet.php)
+    'page_title_edit_pet' => 'Edit Pet Profile',
+    'page_title_edit_pet_name %s' => 'Edit Profile for %s', // %s is pet name
+    'error_invalid_pet_id_for_edit' => 'No pet specified or invalid ID for editing.',
+    'error_pet_not_found_or_not_owned' => 'Pet profile not found or you do not have permission to edit it.',
+    'edit_pet_form_title' => "Update Your Pet's Details",
+    'edit_pet_section_avatar' => 'Update Profile Picture',
+    'label_pet_avatar_new' => 'Upload New Avatar (Optional)',
+    'edit_pet_current_avatar_label' => 'Current Avatar:',
+    'edit_pet_remove_avatar_checkbox_label' => 'Remove current avatar (will be replaced if new avatar is uploaded)',
+    'alt_new_pet_avatar_preview' => 'New Avatar Preview',
+    'button_update_pet_submit' => 'Update Pet Profile',
+    'edit_pet_alert_success' => 'Pet profile updated successfully!',
+    'edit_pet_alert_failed_unknown' => 'Failed to update pet profile. Please check the form for errors.',
+    'edit_pet_alert_failed_network' => 'A network error occurred while updating the pet profile. Please try again.',
+
     // Profile Update API (api/v1/user/profile-update.php)
     'error_profile_update_mismatch' => 'Profile update authorization failed. Please ensure you are logged in correctly.',
     // 'error_username_taken' is reused
@@ -398,6 +414,24 @@ return [
     'recognize_failed_message_short' => 'Recognition failed.',
     'recognize_button_already_recognized_text' => 'Already Recognized',
     'recognize_failed_network' => 'A network error occurred. Please try again.',
+    'tooltip_already_recognized' => "You've already recognized this place. Thank you!",
+
+    // Edit Pet API (api/v1/pets/update.php)
+    'error_invalid_pet_id_for_edit_api' => 'Invalid pet ID specified for update.',
+    'error_pet_not_found_or_not_owned_api' => 'Pet profile not found, or you are not authorized to edit it.',
+    'edit_pet_no_changes_detected' => 'No changes were detected in the pet profile information.',
+    'edit_pet_api_success' => 'Pet profile updated successfully!',
+    'edit_pet_api_failed_db' => 'Failed to update pet profile due to a database error. Please try again.',
+    // Validation errors (e.g., error_pet_name_required) are often reused from Add Pet API
+
+    // View Pet Page (pages/pets/view-pet.php)
+    'page_title_view_pet_default' => 'View Pet Profile',
+    'error_invalid_pet_id_for_view' => 'No pet specified or invalid ID for viewing.',
+    'error_pet_not_found_or_not_owned_view' => 'Pet profile not found or you do not have permission to view it.',
+    'page_title_view_pet_name %s' => 'Viewing Profile for %s', // %s is pet name
+    'button_edit_this_pet' => 'Edit This Pet',
+    'view_pet_section_details' => 'Pet Details',
+    'pet_age_years_months %d %d' => 'Approx. %d years, %d months old', // %d for years, %d for months
 
     // Add more translations as features are developed...
 ];

--- a/pawsroam-webapp/pages/business-detail.php
+++ b/pawsroam-webapp/pages/business-detail.php
@@ -91,7 +91,7 @@ if (empty($pageTitle) && $error_message) {
                                     <i class="bi <?php echo ($i <= (int)$business_data['pawstar_rating']) ? 'bi-star-fill text-warning' : 'bi-star text-body-tertiary'; ?>"></i>
                                 <?php endfor; ?>
                             </span>
-                            <span class="me-3"><i class="bi bi-award me-1"></i><?php echo e($business_data['total_recognitions'] ?? 0); ?> <?php echo e(__('recognitions_text', [], $GLOBALS['current_language'] ?? 'en')); ?></span>
+                            <span class="me-3"><i class="bi bi-award me-1"></i><span id="totalRecognitionsCount"><?php echo e($business_data['total_recognitions'] ?? 0); ?></span> <?php echo e(__('recognitions_text', [], $GLOBALS['current_language'] ?? 'en')); ?></span>
                             <?php /* <span class="me-3"><i class="bi bi-tag me-1"></i> <a href="#" class="text-decoration-none">Cafe</a></span> */ ?>
                         </div>
                         <p class="text-muted fst-italic"><?php echo e(__('address_placeholder_short', [], $GLOBALS['current_language'] ?? 'en')); // "Example: Pawsville, Petland" ?></p>

--- a/pawsroam-webapp/pages/pet-profile.php
+++ b/pawsroam-webapp/pages/pet-profile.php
@@ -92,15 +92,15 @@ try {
                                 </div>
                             </div>
                             <div class="mt-2 mt-md-0 text-md-end">
-                                <a href="<?php echo e(base_url('/pets/view/' . $pet['id'])); ?>" class="btn btn-sm btn-outline-info me-1 disabled" title="<?php echo e(sprintf(__('tooltip_view_pet %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>" aria-disabled="true">
+                                <a href="<?php echo e(base_url('/pets/view/' . $pet['id'])); ?>" class="btn btn-sm btn-outline-info me-1" title="<?php echo e(sprintf(__('tooltip_view_pet_profile %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>">
                                     <i class="bi bi-eye-fill"></i> <?php echo e(__('button_view', [], $GLOBALS['current_language'] ?? 'en')); ?>
                                 </a>
-                                <a href="<?php echo e(base_url('/pets/edit/' . $pet['id'])); ?>" class="btn btn-sm btn-outline-primary me-1 disabled" title="<?php echo e(sprintf(__('tooltip_edit_pet %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>" aria-disabled="true">
+                                <a href="<?php echo e(base_url('/pets/edit/' . $pet['id'])); ?>" class="btn btn-sm btn-outline-primary me-1" title="<?php echo e(sprintf(__('tooltip_edit_pet_profile %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>">
                                     <i class="bi bi-pencil-fill"></i> <?php echo e(__('button_edit', [], $GLOBALS['current_language'] ?? 'en')); ?>
                                 </a>
-                                <button type="button" class="btn btn-sm btn-outline-danger disabled"
+                                <button type="button" class="btn btn-sm btn-outline-danger"
                                         data-bs-toggle="modal" data-bs-target="#deletePetModal"
-                                        data-pet-id="<?php echo e($pet['id']); ?>" data-pet-name="<?php echo e(e($pet['name'])); ?>" title="<?php echo e(sprintf(__('tooltip_delete_pet %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>" aria-disabled="true">
+                                        data-pet-id="<?php echo e($pet['id']); ?>" data-pet-name="<?php echo e(e($pet['name'])); ?>" title="<?php echo e(sprintf(__('tooltip_delete_pet_profile %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet['name']))); ?>">
                                     <i class="bi bi-trash-fill"></i> <?php echo e(__('button_delete', [], $GLOBALS['current_language'] ?? 'en')); ?>
                                 </button>
                             </div>

--- a/pawsroam-webapp/pages/pets/edit-pet.php
+++ b/pawsroam-webapp/pages/pets/edit-pet.php
@@ -1,0 +1,326 @@
+<?php
+require_login();
+
+$pageTitle = __('page_title_edit_pet', [], $GLOBALS['current_language'] ?? 'en'); // "Edit Pet Profile"
+$user_id = current_user_id();
+$pet_id = filter_var($_GET['id'] ?? null, FILTER_VALIDATE_INT);
+$pet_data = null;
+$error_message = null;
+
+if (!$pet_id) {
+    $error_message = __('error_invalid_pet_id_for_edit', [], $GLOBALS['current_language'] ?? 'en'); // "No pet specified or invalid ID for editing."
+    http_response_code(400);
+} else {
+    try {
+        $db = Database::getInstance()->getConnection();
+        $stmt = $db->prepare("SELECT * FROM user_pets WHERE id = :pet_id AND user_id = :user_id LIMIT 1");
+        $stmt->bindParam(':pet_id', $pet_id, PDO::PARAM_INT);
+        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt->execute();
+        $pet_data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$pet_data) {
+            $error_message = __('error_pet_not_found_or_not_owned', [], $GLOBALS['current_language'] ?? 'en'); // "Pet profile not found or you do not have permission to edit it."
+            http_response_code(404); // Or 403 if found but not owned
+        } else {
+            $pageTitle = sprintf(__('page_title_edit_pet_name %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet_data['name'])); // "Edit Profile for [Pet Name]"
+            // Decode JSON fields for form pre-fill if they were stored as JSON strings of arrays
+            $pet_data['personality_traits'] = !empty($pet_data['personality_traits']) ? implode(', ', json_decode($pet_data['personality_traits'], true) ?: []) : '';
+            $pet_data['medical_conditions'] = !empty($pet_data['medical_conditions']) ? implode(', ', json_decode($pet_data['medical_conditions'], true) ?: []) : '';
+            $pet_data['dietary_restrictions'] = !empty($pet_data['dietary_restrictions']) ? implode(', ', json_decode($pet_data['dietary_restrictions'], true) ?: []) : '';
+        }
+    } catch (PDOException $e) {
+        error_log("Database error fetching pet for edit (ID: {$pet_id}, User: {$user_id}): " . $e->getMessage());
+        $error_message = __('error_pet_profiles_load_failed_db', [], $GLOBALS['current_language'] ?? 'en');
+        http_response_code(500);
+    }
+}
+
+// Data for dropdowns
+$pet_species_options = [ /* ... copy from add-pet.php or centralize ... */
+    'dog' => __('pet_species_dog', [], $GLOBALS['current_language'] ?? 'en'), 'cat' => __('pet_species_cat', [], $GLOBALS['current_language'] ?? 'en'), 'bird' => __('pet_species_bird', [], $GLOBALS['current_language'] ?? 'en'), 'rabbit' => __('pet_species_rabbit', [], $GLOBALS['current_language'] ?? 'en'), 'other' => __('pet_species_other', [], $GLOBALS['current_language'] ?? 'en'),];
+$pet_size_options = [ /* ... copy from add-pet.php or centralize ... */
+    '' => __('select_option_placeholder', [], $GLOBALS['current_language'] ?? 'en') . __('pet_size_label', [], $GLOBALS['current_language'] ?? 'en'), 'small' => __('pet_size_small', [], $GLOBALS['current_language'] ?? 'en'), 'medium' => __('pet_size_medium', [], $GLOBALS['current_language'] ?? 'en'), 'large' => __('pet_size_large', [], $GLOBALS['current_language'] ?? 'en'), 'extra_large' => __('pet_size_extra_large', [], $GLOBALS['current_language'] ?? 'en'),];
+
+if (empty($_SESSION[CSRF_TOKEN_NAME ?? 'csrf_token'])) { generate_csrf_token(true); }
+?>
+
+<div class="container my-4 my-md-5">
+    <div class="row mb-4 align-items-center">
+        <div class="col">
+            <h1 class="display-6 fw-bold"><?php echo e($pageTitle); ?></h1>
+        </div>
+        <div class="col text-end">
+            <a href="<?php echo e(base_url('/pet-profile')); ?>" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left-circle me-2"></i><?php echo e(__('button_back_to_my_pets', [], $GLOBALS['current_language'] ?? 'en')); ?>
+            </a>
+        </div>
+    </div>
+
+    <?php if ($error_message): ?>
+        <div class="alert alert-danger shadow-sm" role="alert">
+            <h4 class="alert-heading"><i class="bi bi-exclamation-triangle-fill me-2"></i><?php echo e(__('error_oops_title', [], $GLOBALS['current_language'] ?? 'en')); ?></h4>
+            <p><?php echo e($error_message); ?></p>
+        </div>
+    <?php elseif ($pet_data): ?>
+    <div class="card shadow-lg border-0">
+        <div class="card-header bg-primary-orange text-white py-3">
+            <h2 class="h4 mb-0"><i class="bi bi-pencil-square me-2"></i><?php echo e(__('edit_pet_form_title', [], $GLOBALS['current_language'] ?? 'en')); // "Update Your Pet's Details" ?></h2>
+        </div>
+        <div class="card-body p-4 p-md-5">
+            <form id="editPetForm" action="<?php echo e(base_url('/api/v1/pets/update.php')); ?>" method="POST" enctype="multipart/form-data" novalidate>
+                <?php echo csrf_input_field(); ?>
+                <input type="hidden" name="pet_id" value="<?php echo e($pet_data['id']); ?>">
+
+                <div id="editPetFormMessages" class="mb-3" role="alert" aria-live="assertive"></div>
+
+                <fieldset>
+                    <legend class="h5 fw-semibold mb-3 border-bottom pb-2 text-text-dark"><?php echo e(__('add_pet_section_basic_info', [], $GLOBALS['current_language'] ?? 'en')); ?></legend>
+                    <div class="row g-3">
+                        <div class="col-md-6 form-floating mb-3">
+                            <input type="text" class="form-control" id="pet_name" name="name" value="<?php echo e($pet_data['name']); ?>" placeholder="<?php echo e(__('placeholder_pet_name', [], $GLOBALS['current_language'] ?? 'en')); ?>" required maxlength="100">
+                            <label for="pet_name"><?php echo e(__('label_pet_name', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                            <div class="invalid-feedback" id="nameError"></div>
+                        </div>
+                        <div class="col-md-6 form-floating mb-3">
+                            <select class="form-select" id="pet_species" name="species" required>
+                                <?php foreach($pet_species_options as $value => $label): ?>
+                                <option value="<?php echo e($value); ?>" <?php echo ($pet_data['species'] == $value) ? 'selected' : ''; ?>><?php echo e($label); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <label for="pet_species"><?php echo e(__('label_pet_species', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                            <div class="invalid-feedback" id="speciesError"></div>
+                        </div>
+                        <div class="col-md-6 form-floating mb-3">
+                            <input type="text" class="form-control" id="pet_breed" name="breed" value="<?php echo e($pet_data['breed']); ?>" placeholder="<?php echo e(__('placeholder_pet_breed', [], $GLOBALS['current_language'] ?? 'en')); ?>" maxlength="100">
+                            <label for="pet_breed"><?php echo e(__('label_pet_breed', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                            <div class="invalid-feedback" id="breedError"></div>
+                        </div>
+                         <div class="col-md-6 form-floating mb-3">
+                            <input type="date" class="form-control" id="pet_birthdate" name="birthdate" value="<?php echo e($pet_data['birthdate']); ?>" max="<?php echo date('Y-m-d'); ?>">
+                            <label for="pet_birthdate"><?php echo e(__('label_pet_birthdate', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                            <div class="invalid-feedback" id="birthdateError"></div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <hr class="my-4">
+
+                <fieldset>
+                    <legend class="h5 fw-semibold mb-3 border-bottom pb-2 text-text-dark"><?php echo e(__('add_pet_section_physical_details', [], $GLOBALS['current_language'] ?? 'en')); ?></legend>
+                     <div class="row g-3">
+                        <div class="col-md-6 form-floating mb-3">
+                            <select class="form-select" id="pet_size" name="size">
+                                <?php foreach($pet_size_options as $value => $label): ?>
+                                <option value="<?php echo e($value); ?>" <?php echo ($pet_data['size'] == $value) ? 'selected' : ''; ?>><?php echo e($label); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <label for="pet_size"><?php echo e(__('label_pet_size', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                             <div class="invalid-feedback" id="sizeError"></div>
+                        </div>
+                        <div class="col-md-6 form-floating mb-3">
+                            <input type="number" class="form-control" id="pet_weight_kg" name="weight_kg" value="<?php echo e($pet_data['weight_kg']); ?>" placeholder="e.g., 5.5" step="0.1" min="0.1" max="150">
+                            <label for="pet_weight_kg"><?php echo e(__('label_pet_weight_kg', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                            <div class="invalid-feedback" id="weight_kgError"></div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <hr class="my-4">
+
+                 <fieldset>
+                    <legend class="h5 fw-semibold mb-3 border-bottom pb-2 text-text-dark"><?php echo e(__('add_pet_section_characteristics', [], $GLOBALS['current_language'] ?? 'en')); ?></legend>
+                    <div class="mb-3">
+                        <label for="pet_personality_traits" class="form-label"><?php echo e(__('label_pet_personality', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                        <textarea class="form-control" id="pet_personality_traits" name="personality_traits" rows="3" placeholder="<?php echo e(__('placeholder_pet_personality', [], $GLOBALS['current_language'] ?? 'en')); ?>"><?php echo e($pet_data['personality_traits']); ?></textarea>
+                        <small class="form-text text-muted"><?php echo e(__('help_text_pet_personality', [], $GLOBALS['current_language'] ?? 'en')); ?></small>
+                        <div class="invalid-feedback" id="personality_traitsError"></div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="pet_medical_conditions" class="form-label"><?php echo e(__('label_pet_medical', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                        <textarea class="form-control" id="pet_medical_conditions" name="medical_conditions" rows="3" placeholder="<?php echo e(__('placeholder_pet_medical', [], $GLOBALS['current_language'] ?? 'en')); ?>"><?php echo e($pet_data['medical_conditions']); ?></textarea>
+                         <div class="invalid-feedback" id="medical_conditionsError"></div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="pet_dietary_restrictions" class="form-label"><?php echo e(__('label_pet_dietary', [], $GLOBALS['current_language'] ?? 'en')); ?></label>
+                        <textarea class="form-control" id="pet_dietary_restrictions" name="dietary_restrictions" rows="3" placeholder="<?php echo e(__('placeholder_pet_dietary', [], $GLOBALS['current_language'] ?? 'en')); ?>"><?php echo e($pet_data['dietary_restrictions']); ?></textarea>
+                        <div class="invalid-feedback" id="dietary_restrictionsError"></div>
+                    </div>
+                </fieldset>
+
+                <hr class="my-4">
+
+                <fieldset>
+                     <legend class="h5 fw-semibold mb-3 border-bottom pb-2 text-text-dark"><?php echo e(__('edit_pet_section_avatar', [], $GLOBALS['current_language'] ?? 'en')); // "Update Profile Picture" ?></legend>
+                    <div class="mb-3">
+                        <label for="pet_avatar_new" class="form-label"><?php echo e(__('label_pet_avatar_new', [], $GLOBALS['current_language'] ?? 'en')); // "Upload New Avatar (Optional)" ?></label>
+                        <input class="form-control" type="file" id="pet_avatar_new" name="avatar_new" accept="image/jpeg, image/png, image/gif">
+                        <small class="form-text text-muted"><?php echo e(__('help_text_pet_avatar', [], $GLOBALS['current_language'] ?? 'en')); ?></small>
+                        <div class="invalid-feedback" id="avatar_newError"></div>
+                    </div>
+                    <?php if (!empty($pet_data['avatar_path'])): ?>
+                    <div class="mb-3">
+                        <p><?php echo e(__('edit_pet_current_avatar_label', [], $GLOBALS['current_language'] ?? 'en')); // "Current Avatar:" ?></p>
+                        <img id="currentAvatarPreview" src="<?php echo e(rtrim(UPLOADS_BASE_URL ?? base_url('/uploads'), '/') . '/' . ltrim($pet_data['avatar_path'], '/')); ?>" alt="<?php echo e(sprintf(__('pet_avatar_alt %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet_data['name']))); ?>" class="img-thumbnail rounded-circle" style="width: 100px; height: 100px; object-fit: cover;">
+                        <div class="form-check mt-2">
+                            <input class="form-check-input" type="checkbox" value="1" id="remove_current_avatar" name="remove_current_avatar">
+                            <label class="form-check-label" for="remove_current_avatar">
+                                <?php echo e(__('edit_pet_remove_avatar_checkbox_label', [], $GLOBALS['current_language'] ?? 'en')); // "Remove current avatar" ?>
+                            </label>
+                        </div>
+                    </div>
+                    <?php endif; ?>
+                    <img id="newAvatarPreview" src="#" alt="<?php echo e(__('alt_new_pet_avatar_preview', [], $GLOBALS['current_language'] ?? 'en')); // "New Avatar Preview" ?>" class="mt-2 img-thumbnail rounded-circle d-none" style="width: 100px; height: 100px; object-fit: cover;"/>
+                </fieldset>
+
+                <div class="mt-4 pt-3 border-top">
+                    <button type="submit" class="btn btn-primary btn-lg px-5" id="editPetButton">
+                        <span class="button-text"><?php echo e(__('button_update_pet_submit', [], $GLOBALS['current_language'] ?? 'en')); // "Update Pet Profile" ?></span>
+                        <span class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"></span>
+                    </button>
+                    <a href="<?php echo e(base_url('/pet-profile')); ?>" class="btn btn-link text-muted ms-2"><?php echo e(__('button_cancel', [], $GLOBALS['current_language'] ?? 'en')); ?></a>
+                </div>
+            </form>
+        </div>
+    </div>
+    <?php else: ?>
+        <?php // This part is hit if $pet_data is null AND there was no $error_message initially set, which means no ID was passed.
+              // The initial $error_message for no pet_id handles this.
+              // If $error_message was set, it's displayed above.
+        ?>
+    <?php endif; ?>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const editPetForm = document.getElementById('editPetForm');
+    if (!editPetForm) return;
+
+    const editPetButton = document.getElementById('editPetButton');
+    const buttonText = editPetButton.querySelector('.button-text');
+    const spinner = editPetButton.querySelector('.spinner-border');
+    const formMessages = document.getElementById('editPetFormMessages');
+    const avatarInput = document.getElementById('pet_avatar_new');
+    const newAvatarPreview = document.getElementById('newAvatarPreview');
+    const currentAvatarPreview = document.getElementById('currentAvatarPreview');
+    const removeAvatarCheckbox = document.getElementById('remove_current_avatar');
+
+    function clearEditPetValidationUI() { /* ... similar to addPetForm ... */
+        editPetForm.querySelectorAll('.form-control, .form-select').forEach(el => el.classList.remove('is-invalid'));
+        editPetForm.querySelectorAll('.invalid-feedback').forEach(el => el.textContent = '');
+        if (formMessages) { formMessages.innerHTML = ''; formMessages.className = 'mb-3'; }
+    }
+    function displayEditPetFormMessage(message, type = 'danger') { /* ... similar ... */
+        if (!formMessages) return;
+        formMessages.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">${escapeHtml(message)}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+    }
+    function displayEditPetFieldErrors(errors) { /* ... similar ... */
+        for (const field in errors) {
+            const inputElement = editPetForm.querySelector(`[name="${field}"]`);
+            const errorElementId = `${field.replace('_new', '')}Error`; // Handle avatar_new mapping to avatarError
+            const errorDiv = document.getElementById(errorElementId) || document.getElementById(field + 'Error');
+            if (inputElement) inputElement.classList.add('is-invalid');
+            if (errorDiv) errorDiv.textContent = errors[field];
+        }
+    }
+    function escapeHtml(unsafe) { /* ... similar ... */
+        if (typeof unsafe !== 'string') return '';
+        return unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+    }
+
+    if (avatarInput && newAvatarPreview) {
+        avatarInput.addEventListener('change', function(event) {
+            const file = event.target.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    newAvatarPreview.src = e.target.result;
+                    newAvatarPreview.classList.remove('d-none');
+                }
+                reader.readAsDataURL(file);
+                if(removeAvatarCheckbox) removeAvatarCheckbox.checked = false; // Uncheck remove if new file selected
+            } else {
+                newAvatarPreview.classList.add('d-none');
+                newAvatarPreview.src = "#";
+            }
+        });
+    }
+    if (removeAvatarCheckbox && currentAvatarPreview) {
+        removeAvatarCheckbox.addEventListener('change', function() {
+            if (this.checked) {
+                currentAvatarPreview.style.opacity = '0.5';
+                if(avatarInput) avatarInput.value = ''; // Clear new avatar input if removing current
+                if(newAvatarPreview) { newAvatarPreview.classList.add('d-none'); newAvatarPreview.src = "#"; }
+            } else {
+                currentAvatarPreview.style.opacity = '1';
+            }
+        });
+    }
+
+
+    editPetForm.addEventListener('submit', async function (event) {
+        event.preventDefault();
+        clearEditPetValidationUI();
+
+        if (buttonText) buttonText.textContent = '<?php echo e(__('state_text_processing', [], $GLOBALS['current_language'] ?? 'en')); ?>';
+        if (spinner) spinner.classList.remove('d-none');
+        editPetButton.disabled = true;
+
+        const formData = new FormData(editPetForm);
+
+        try {
+            const response = await fetch(editPetForm.action, {
+                method: 'POST',
+                body: formData,
+                headers: { 'Accept': 'application/json' }
+            });
+            const result = await response.json();
+
+            if (response.ok && result.success) {
+                displayEditPetFormMessage(result.message || '<?php echo e(__('edit_pet_alert_success', [], $GLOBALS['current_language'] ?? 'en')); // "Pet profile updated successfully!" ?>', 'success');
+                // Optionally update current avatar preview if a new one was set by API
+                if (result.new_avatar_path && currentAvatarPreview) {
+                    currentAvatarPreview.src = '<?php echo rtrim(UPLOADS_BASE_URL ?? base_url("/uploads"), "/"); ?>/' + result.new_avatar_path.ltrim('/');
+                    if(newAvatarPreview) {newAvatarPreview.classList.add('d-none'); newAvatarPreview.src="#";}
+                    if(avatarInput) avatarInput.value = '';
+                } else if (formData.get('remove_current_avatar') && currentAvatarPreview) {
+                    currentAvatarPreview.src = '<?php echo e(base_url("/assets/images/placeholders/pet_avatar_default_64.png")); ?>'; // Or hide it
+                }
+                // No redirect by default, user stays on page to see changes or make more.
+                // Could redirect after delay: setTimeout(() => { window.location.href = '<?php echo e(base_url("/pet-profile")); ?>'; }, 2000);
+            } else {
+                let errorMessage = result.message || '<?php echo e(__('edit_pet_alert_failed_unknown', [], $GLOBALS['current_language'] ?? 'en')); // "Failed to update pet. Please check errors." ?>';
+                if (result.errors) {
+                    displayEditPetFieldErrors(result.errors);
+                }
+                displayEditPetFormMessage(errorMessage, 'danger');
+            }
+        } catch (error) {
+            console.error('Edit Pet submission error:', error);
+            displayEditPetFormMessage('<?php echo e(__('edit_pet_alert_failed_network', [], $GLOBALS['current_language'] ?? 'en')); // "A network error occurred. Please try again." ?>', 'danger');
+        } finally {
+            if (buttonText) buttonText.textContent = '<?php echo e(__('button_update_pet_submit', [], $GLOBALS['current_language'] ?? 'en')); ?>';
+            if (spinner) spinner.classList.add('d-none');
+            editPetButton.disabled = false;
+        }
+    });
+});
+</script>
+<?php
+// Translation placeholders
+// __('page_title_edit_pet', [], $GLOBALS['current_language'] ?? 'en');
+// __('error_invalid_pet_id_for_edit', [], $GLOBALS['current_language'] ?? 'en');
+// __('error_pet_not_found_or_not_owned', [], $GLOBALS['current_language'] ?? 'en');
+// __('page_title_edit_pet_name %s', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_form_title', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_section_avatar', [], $GLOBALS['current_language'] ?? 'en');
+// __('label_pet_avatar_new', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_current_avatar_label', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_remove_avatar_checkbox_label', [], $GLOBALS['current_language'] ?? 'en');
+// __('alt_new_pet_avatar_preview', [], $GLOBALS['current_language'] ?? 'en');
+// __('button_update_pet_submit', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_alert_success', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_alert_failed_unknown', [], $GLOBALS['current_language'] ?? 'en');
+// __('edit_pet_alert_failed_network', [], $GLOBALS['current_language'] ?? 'en');
+// Reused from add-pet: species_options, size_options, labels for name, species, breed, etc.
+?>

--- a/pawsroam-webapp/pages/pets/view-pet.php
+++ b/pawsroam-webapp/pages/pets/view-pet.php
@@ -1,0 +1,174 @@
+<?php
+require_login();
+
+$pageTitle = __('page_title_view_pet_default', [], $GLOBALS['current_language'] ?? 'en'); // "View Pet Profile"
+$user_id = current_user_id();
+$pet_id = filter_var($_GET['id'] ?? null, FILTER_VALIDATE_INT);
+$pet_data = null;
+$error_message = null;
+
+if (!$pet_id) {
+    $error_message = __('error_invalid_pet_id_for_view', [], $GLOBALS['current_language'] ?? 'en'); // "No pet specified or invalid ID for viewing."
+    http_response_code(400);
+} else {
+    try {
+        $db = Database::getInstance()->getConnection();
+        $stmt = $db->prepare("SELECT * FROM user_pets WHERE id = :pet_id AND user_id = :user_id LIMIT 1");
+        $stmt->bindParam(':pet_id', $pet_id, PDO::PARAM_INT);
+        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
+        $stmt->execute();
+        $pet_data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$pet_data) {
+            $error_message = __('error_pet_not_found_or_not_owned_view', [], $GLOBALS['current_language'] ?? 'en'); // "Pet profile not found or you do not have permission to view it."
+            http_response_code(404);
+        } else {
+            $pageTitle = sprintf(__('page_title_view_pet_name %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet_data['name'])); // "Viewing Profile for [Pet Name]"
+        }
+    } catch (PDOException $e) {
+        error_log("Database error fetching pet for view (ID: {$pet_id}, User: {$user_id}): " . $e->getMessage());
+        $error_message = __('error_pet_profiles_load_failed_db', [], $GLOBALS['current_language'] ?? 'en'); // Reusing
+        http_response_code(500);
+    }
+}
+
+if (empty($pageTitle) && $error_message) { // Set error title if needed
+    $pageTitle = __('page_title_error', [], $GLOBALS['current_language'] ?? 'en') . " - " . (defined('APP_NAME') ? APP_NAME : 'PawsRoam');
+}
+
+/**
+ * Helper to display a JSON field as a list or simple text.
+ */
+function display_json_field_as_list($json_string, $default_text = 'N/A') {
+    if (empty($json_string)) return e($default_text);
+    $data = json_decode($json_string, true);
+    if (json_last_error() === JSON_ERROR_NONE && is_array($data) && !empty($data)) {
+        if (count($data) > 1) {
+            $html = '<ul class="list-unstyled mb-0">';
+            foreach ($data as $item) {
+                $html .= '<li><i class="bi bi-dot me-1"></i>' . e($item) . '</li>';
+            }
+            $html .= '</ul>';
+            return $html;
+        } elseif (count($data) === 1) {
+            return e($data[0]);
+        }
+    } elseif (!empty($json_string) && (json_last_error() !== JSON_ERROR_NONE || !is_array($data))) {
+        // If it's not valid JSON or not an array, but has content, display as is (escaped)
+        // This handles cases where plain text was entered instead of comma-separated for traits.
+        return nl2br(e($json_string));
+    }
+    return e($default_text);
+}
+?>
+
+<div class="container my-4 my-md-5">
+    <div class="row mb-4 align-items-center">
+        <div class="col">
+            <h1 class="display-6 fw-bold"><?php echo e($pageTitle); ?></h1>
+        </div>
+        <div class="col text-end">
+            <a href="<?php echo e(base_url('/pet-profile')); ?>" class="btn btn-outline-secondary me-2">
+                <i class="bi bi-arrow-left-circle me-2"></i><?php echo e(__('button_back_to_my_pets', [], $GLOBALS['current_language'] ?? 'en')); ?>
+            </a>
+            <?php if ($pet_data): ?>
+            <a href="<?php echo e(base_url('/pets/edit/' . $pet_data['id'])); ?>" class="btn btn-primary">
+                <i class="bi bi-pencil-square me-2"></i><?php echo e(__('button_edit_this_pet', [], $GLOBALS['current_language'] ?? 'en')); // "Edit This Pet" ?>
+            </a>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <?php if ($error_message): ?>
+        <div class="alert alert-danger shadow-sm" role="alert">
+            <h4 class="alert-heading"><i class="bi bi-exclamation-triangle-fill me-2"></i><?php echo e(__('error_oops_title', [], $GLOBALS['current_language'] ?? 'en')); ?></h4>
+            <p><?php echo e($error_message); ?></p>
+        </div>
+    <?php elseif ($pet_data): ?>
+    <div class="card shadow-lg border-0">
+        <div class="row g-0">
+            <div class="col-md-4 bg-light text-center p-4 d-flex flex-column align-items-center justify-content-center border-end">
+                <?php
+                    $avatar_url = base_url('/assets/images/placeholders/pet_avatar_default_200.png'); // Larger default
+                    if (!empty($pet_data['avatar_path']) && defined('UPLOADS_BASE_URL')) {
+                        $avatar_url = rtrim(UPLOADS_BASE_URL, '/') . '/' . ltrim($pet_data['avatar_path'], '/');
+                    }
+                ?>
+                <img src="<?php echo e($avatar_url); ?>"
+                     alt="<?php echo e(sprintf(__('pet_avatar_alt %s', [], $GLOBALS['current_language'] ?? 'en'), e($pet_data['name']))); ?>"
+                     class="img-fluid rounded-circle shadow mb-3" style="width: 200px; height: 200px; object-fit: cover;">
+                <h2 class="h3 text-primary-orange mb-1"><?php echo e($pet_data['name']); ?></h2>
+                <p class="text-muted mb-0">
+                    <?php echo e(ucfirst($pet_data['species'])); ?>
+                    <?php if (!empty($pet_data['breed'])): ?>
+                        &bull; <?php echo e(e($pet_data['breed'])); ?>
+                    <?php endif; ?>
+                </p>
+            </div>
+            <div class="col-md-8">
+                <div class="card-body p-4 p-lg-5">
+                    <h3 class="h5 fw-semibold mb-3 border-bottom pb-2 text-text-dark"><?php echo e(__('view_pet_section_details', [], $GLOBALS['current_language'] ?? 'en')); // "Pet Details" ?></h3>
+                    <dl class="row">
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_name', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e($pet_data['name']); ?></dd>
+
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_species', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e(ucfirst($pet_data['species'])); ?></dd>
+
+                        <?php if (!empty($pet_data['breed'])): ?>
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_breed', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e($pet_data['breed']); ?></dd>
+                        <?php endif; ?>
+
+                        <?php if (!empty($pet_data['birthdate'])): ?>
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_birthdate', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e(date("F j, Y", strtotime($pet_data['birthdate']))); ?> (<?php
+                            $birthDate = new DateTime($pet_data['birthdate']);
+                            $today = new DateTime();
+                            $age = $today->diff($birthDate);
+                            echo e(sprintf(__("pet_age_years_months %d %d", [], $GLOBALS['current_language'] ?? 'en'), $age->y, $age->m)); // "Approx. %d years, %d months old"
+                        ?>)</dd>
+                        <?php endif; ?>
+
+                        <?php if (!empty($pet_data['size'])): ?>
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_size', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e(ucfirst($pet_data['size'])); ?></dd>
+                        <?php endif; ?>
+
+                        <?php if (!empty($pet_data['weight_kg'])): ?>
+                        <dt class="col-sm-4 col-md-3"><?php echo e(__('label_pet_weight_kg', [], $GLOBALS['current_language'] ?? 'en')); ?></dt>
+                        <dd class="col-sm-8 col-md-9"><?php echo e($pet_data['weight_kg']); ?> kg</dd>
+                        <?php endif; ?>
+                    </dl>
+
+                    <?php if (!empty($pet_data['personality_traits'])): ?>
+                    <h4 class="h6 fw-semibold mt-4 mb-2 text-text-dark"><?php echo e(__('label_pet_personality', [], $GLOBALS['current_language'] ?? 'en')); ?></h4>
+                    <div class="ps-2"><?php echo display_json_field_as_list($pet_data['personality_traits']); ?></div>
+                    <?php endif; ?>
+
+                    <?php if (!empty($pet_data['medical_conditions'])): ?>
+                    <h4 class="h6 fw-semibold mt-4 mb-2 text-text-dark"><?php echo e(__('label_pet_medical', [], $GLOBALS['current_language'] ?? 'en')); ?></h4>
+                     <div class="ps-2"><?php echo display_json_field_as_list($pet_data['medical_conditions']); ?></div>
+                    <?php endif; ?>
+
+                    <?php if (!empty($pet_data['dietary_restrictions'])): ?>
+                    <h4 class="h6 fw-semibold mt-4 mb-2 text-text-dark"><?php echo e(__('label_pet_dietary', [], $GLOBALS['current_language'] ?? 'en')); ?></h4>
+                     <div class="ps-2"><?php echo display_json_field_as_list($pet_data['dietary_restrictions']); ?></div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+</div>
+<?php
+// Translation placeholders
+// __('page_title_view_pet_default', [], $GLOBALS['current_language'] ?? 'en');
+// __('error_invalid_pet_id_for_view', [], $GLOBALS['current_language'] ?? 'en');
+// __('error_pet_not_found_or_not_owned_view', [], $GLOBALS['current_language'] ?? 'en');
+// __('page_title_view_pet_name %s', [], $GLOBALS['current_language'] ?? 'en');
+// __('button_edit_this_pet', [], $GLOBALS['current_language'] ?? 'en');
+// __('view_pet_section_details', [], $GLOBALS['current_language'] ?? 'en');
+// __("pet_age_years_months %d %d", [], $GLOBALS['current_language'] ?? 'en');
+// Reused: error_oops_title, error_pet_profiles_load_failed_db, button_back_to_my_pets, pet_avatar_alt %s, labels for name, species, etc.
+?>


### PR DESCRIPTION
- Implemented "Edit Pet" functionality:
  - Created `pages/pets/edit-pet.php` with pre-filled form, avatar update/remove options.
  - Created `api/v1/pets/update.php` to handle updates, including avatar changes (new upload, old file deletion) and ownership verification.
- Created "View Pet" detail page (`pages/pets/view-pet.php`):
  - Displays all pet details (read-only) with ownership check.
  - Includes link to edit pet.
- Updated `pages/pet-profile.php`:
  - Enabled "View" and "Edit" buttons, linking to new detail/edit pages.
- Refined "Recognize Business" button on `pages/business-detail.php`:
  - PHP now sets initial button state if user has already recognized the business.
  - JavaScript correctly updates the total recognitions count on the page.
- Updated `index.php` router to handle `/pets/edit/{id}` and `/pets/view/{id}`.
- Added all necessary translation strings for new features and UI messages.